### PR TITLE
Cliffy name + description + help command for subcommands

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,6 @@
 export { Logger } from 'https://deno.land/x/danet/src/logger.ts';
 export { toPathString } from 'https://deno.land/std/fs/_util.ts';
-export { Command } from 'https://deno.land/x/cliffy@v0.25.2/command/mod.ts';
+export { Command, HelpCommand } from 'https://deno.land/x/cliffy@v0.25.2/command/mod.ts';
 export {
 	ClassDeclaration,
 	Decorator,

--- a/main.ts
+++ b/main.ts
@@ -1,13 +1,14 @@
-import { Command } from './deps.ts';
+import { Command, HelpCommand } from './deps.ts';
 import { generateProject } from './generate.ts';
 import { runProject, runProjectWithWatch } from "./run.ts";
 import { bundleProject } from "./bundle.ts";
 
-const program	 = new Command().name('danet')
+const program = new Command().name('danet')
 			.description('Danet CLI Interface')
 			.meta("deno", Deno.version.deno)
 			.meta("v8", Deno.version.v8)
-			.meta("typescript", Deno.version.typescript);
+			.meta("typescript", Deno.version.typescript)
+			.command("help", new HelpCommand().global());
 
 program.command('new').arguments('<name:string>')
 	.option('--postgres', 'Setup project with postgres code')

--- a/main.ts
+++ b/main.ts
@@ -3,7 +3,11 @@ import { generateProject } from './generate.ts';
 import { runProject, runProjectWithWatch } from "./run.ts";
 import { bundleProject } from "./bundle.ts";
 
-const program = new Command().name('danet').description('Danet CLI Interface');
+const program	 = new Command().name('danet')
+			.description('Danet CLI Interface')
+			.meta("deno", Deno.version.deno)
+			.meta("v8", Deno.version.v8)
+			.meta("typescript", Deno.version.typescript);
 
 program.command('new').arguments('<name:string>')
 	.option('--postgres', 'Setup project with postgres code')

--- a/main.ts
+++ b/main.ts
@@ -11,15 +11,22 @@ const program = new Command().name('danet')
 			.command("help", new HelpCommand().global());
 
 program.command('new').arguments('<name:string>')
+	.description('Generate a new project')
 	.option('--postgres', 'Setup project with postgres code')
 	.option('--mongodb', 'Setup project with mongodb code')
 	.option('--in-memory', 'Setup project with in-memory code')
 	.action(generateProject);
 
-program.command('develop').action(runProjectWithWatch);
+program.command('develop')
+	.description('Run project in development mode with HotReload')
+	.action(runProjectWithWatch);
 
-program.command('start').action(runProject);
+program.command('start')
+	.description('Run project in production mode')
+	.action(runProject);
 
-program.command('bundle').arguments('<name:string>').action(bundleProject);
+program.command('bundle')
+	.description('Bundle project into a single file')
+	.arguments('<name:string>').action(bundleProject);
 
 await program.parse(Deno.args);

--- a/main.ts
+++ b/main.ts
@@ -3,7 +3,7 @@ import { generateProject } from './generate.ts';
 import { runProject, runProjectWithWatch } from "./run.ts";
 import { bundleProject } from "./bundle.ts";
 
-const program = new Command('danet');
+const program = new Command().name('danet').description('Danet CLI Interface');
 
 program.command('new').arguments('<name:string>')
 	.option('--postgres', 'Setup project with postgres code')


### PR DESCRIPTION
This should replace Usage: COMMAND with Usage: danet
 
<img width="654" alt="image" src="https://user-images.githubusercontent.com/631881/231478848-d7528d1a-5be0-4222-93c9-046aabfab92b.png">


Adds help output for subcommands 
`danet new --help`
`danet --help new`
`danet help new`
<img width="576" alt="image" src="https://user-images.githubusercontent.com/631881/231480701-02839c38-71a8-49c7-b34b-4a19cfd3e3cd.png">

Command descriptions
<img width="610" alt="image" src="https://user-images.githubusercontent.com/631881/231480316-bb0c625d-84a4-4dfb-aced-c63b5ed0a5e8.png">
