### PR TITLE
fix: check if `bundlePath` exists before removing it

### DIFF
--- a/bundle.ts
+++ b/bundle.ts
@@ -1,19 +1,17 @@
 
-const bundlePath = './bundle';
-
-const bundleFolderExists = (folder: string) => 
+const bundleFolderExists = (folder: string) =>
 	Deno.stat(folder)
 		.then(() => true)
 		.catch(() => false);
 
 export const bundleProject = async (
-	options: { entrypoint: string },
+	options: { entrypoint: string, bundlePath = './bundle' },
 	name: string,
 ) => {
 	if (await bundleExists(bundlePath)) {
 		await Deno.remove(bundlePath, { recursive: true });
 	}
-	
+
 	await Deno.mkdir(bundlePath);
 	const p = Deno.run({
 		cmd: ['deno', 'bundle', options.entrypoint, `${bundlePath}/${name}`],

--- a/bundle.ts
+++ b/bundle.ts
@@ -1,21 +1,19 @@
+
 const bundlePath = './bundle';
 
-function bundleExists() {
-	try {
-		Deno.statSync(bundlePath);
-		return true;
-	} catch (_e) {
-		return false;
-	}
-}
+const bundleFolderExists = (folder: string) => 
+	Deno.stat(folder)
+		.then(() => true)
+		.catch(() => false);
 
 export const bundleProject = async (
 	options: { entrypoint: string },
 	name: string,
 ) => {
-	if (bundleExists()) {
+	if (await bundleExists(bundlePath)) {
 		await Deno.remove(bundlePath, { recursive: true });
 	}
+	
 	await Deno.mkdir(bundlePath);
 	const p = Deno.run({
 		cmd: ['deno', 'bundle', options.entrypoint, `${bundlePath}/${name}`],

--- a/bundle.ts
+++ b/bundle.ts
@@ -1,8 +1,24 @@
-export const bundleProject = async (options: { entrypoint: string }, name: string) => {
-    await Deno.remove("./bundle", { recursive: true });
-    await Deno.mkdir('./bundle');
-    const p = Deno.run({
-        cmd: ['deno', 'bundle', options.entrypoint, `./bundle/${name}`]
-    })
-    await p.status();
+const bundlePath = './bundle';
+
+function bundleExists() {
+	try {
+		Deno.statSync(bundlePath);
+		return true;
+	} catch (_e) {
+		return false;
+	}
 }
+
+export const bundleProject = async (
+	options: { entrypoint: string },
+	name: string,
+) => {
+	if (bundleExists()) {
+		await Deno.remove(bundlePath, { recursive: true });
+	}
+	await Deno.mkdir(bundlePath);
+	const p = Deno.run({
+		cmd: ['deno', 'bundle', options.entrypoint, `${bundlePath}/${name}`],
+	});
+	await p.status();
+};


### PR DESCRIPTION
I'm receiving the following error when building my app:

![image](https://github.com/Savory/Danet-CLI/assets/4452113/cd579bf8-6b74-4de4-9008-3de8230178a6)

To solve it, we must check if the `bundlePath` exists before removing it.

**Changes**

- add function `bundleExists`
- add `if` to confirm the bundle path exists before removing it
- shared the `'./bundle'` as the `bundleExists` variable

This closes #6 